### PR TITLE
Workaround missing packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+basic_auth/.htpasswd
+
 .idea
 back/venv
 back/data

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ Things to include:
 How build instructions change from one file to another
 Configuration options
 
+## Setup
+
+### Make htpasswd for basic auth
+
+```bash
+$ mkdir basic_auth
+$ htpasswd -c basic_auth/.htpasswd admin
+```
+
+### Make directory for workbench
+
+We use `/tmp/tf_aarch64/` for workbench for this build tool.
+
+```bash
+$ mkdir /tmp/tf_aarch64
+```
+
+
 ## Running webserver using docker
 
 In the root of the project run

--- a/back/src/worker_threads.py
+++ b/back/src/worker_threads.py
@@ -138,7 +138,7 @@ class BuildScheduler(BaseThread):
                 commands.append(["docker", "build", "-t", image_name, "-f", docker_file, *build_args, "../tfx/"])
 
             # command to copy produced wheels to host
-            commands.append(["docker", "run", "-v", "/tf_aarch64/volumes/builds:/builds", image_name, "cp", "-a", "/wheels/.", "/builds"])
+            commands.append(["docker", "run", "-v", "/tmp/tf_aarch64/volumes/builds:/builds", image_name, "cp", "-a", "/wheels/.", "/builds"])
 
             print("Starting builder")
             builder = Builder(commands=commands, log_file=log_file)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /etc/basic_auth/.htpasswd:/etc/basic_auth/.htpasswd
-      - /tf_aarch64/volumes/builds:/www/media/builds
-      - /tf_aarch64/volumes/logs:/www/media/logs
+      - ./basic_auth/.htpasswd:/etc/basic_auth/.htpasswd
+      - /tmp/tf_aarch64/volumes/builds:/www/media/builds
+      - /tmp/tf_aarch64/volumes/logs:/www/media/logs
       - ./nginx.conf:/etc/nginx/nginx.conf
 
   front:
@@ -30,9 +30,9 @@ services:
       context: ./back
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /tf_aarch64/volumes/builds:/app/builds
-      - /tf_aarch64/volumes/logs:/app/logs
-      - /tf_aarch64/volumes/data:/app/data
+      - /tmp/tf_aarch64/volumes/builds:/app/builds
+      - /tmp/tf_aarch64/volumes/logs:/app/logs
+      - /tmp/tf_aarch64/volumes/data:/app/data
       - ./tensorflow:/tensorflow
       - ./tfx:/tfx
       - ./bazel:/bazel

--- a/tensorflow/Dockerfile_tf210(0,1)
+++ b/tensorflow/Dockerfile_tf210(0,1)
@@ -10,7 +10,7 @@ WORKDIR /tensorflow
 RUN if [ "$MINOR_VERSION" = "x" ] ; then git checkout r2.10 ; else git checkout tags/v2.10.$MINOR_VERSION ; fi
 
 ENV PYTHONUNBUFFERED=1
-RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' && pip install -U keras_applications keras_preprocessing --no-deps
+RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' packaging && pip install -U keras_applications keras_preprocessing --no-deps
 ENV TF_NEED_CUDA=0 \
 TF_NEED_TENSORRT=0 \
 PYTHON_BIN_PATH="/usr/local/bin/python" \

--- a/tensorflow/Dockerfile_tf27(0,1,2,3,4)
+++ b/tensorflow/Dockerfile_tf27(0,1,2,3,4)
@@ -10,7 +10,7 @@ WORKDIR /tensorflow
 RUN if [ "$MINOR_VERSION" = "x" ] ; then git checkout r2.7 ; else git checkout tags/v2.7.$MINOR_VERSION ; fi
 
 ENV PYTHONUNBUFFERED=1
-RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' && pip install -U keras_applications keras_preprocessing --no-deps
+RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' packaging && pip install -U keras_applications keras_preprocessing --no-deps
 ENV TF_NEED_CUDA=0 \
 TF_NEED_TENSORRT=0 \
 PYTHON_BIN_PATH="/usr/local/bin/python" \

--- a/tensorflow/Dockerfile_tf28(0,1,2,3,4)
+++ b/tensorflow/Dockerfile_tf28(0,1,2,3,4)
@@ -10,7 +10,7 @@ WORKDIR /tensorflow
 RUN if [ "$MINOR_VERSION" = "x" ] ; then git checkout r2.8 ; else git checkout tags/v2.8.$MINOR_VERSION ; fi
 
 ENV PYTHONUNBUFFERED=1
-RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' && pip install -U keras_applications keras_preprocessing --no-deps
+RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' packaging && pip install -U keras_applications keras_preprocessing --no-deps
 ENV TF_NEED_CUDA=0 \
 TF_NEED_TENSORRT=0 \
 PYTHON_BIN_PATH="/usr/local/bin/python" \

--- a/tensorflow/Dockerfile_tf29(0,1,2,3)
+++ b/tensorflow/Dockerfile_tf29(0,1,2,3)
@@ -10,7 +10,7 @@ WORKDIR /tensorflow
 RUN if [ "$MINOR_VERSION" = "x" ] ; then git checkout r2.9 ; else git checkout tags/v2.9.$MINOR_VERSION ; fi
 
 ENV PYTHONUNBUFFERED=1
-RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' && pip install -U keras_applications keras_preprocessing --no-deps
+RUN pip install -U pip six 'numpy<1.19.0' wheel setuptools mock 'future>=0.17.1' packaging && pip install -U keras_applications keras_preprocessing --no-deps
 ENV TF_NEED_CUDA=0 \
 TF_NEED_TENSORRT=0 \
 PYTHON_BIN_PATH="/usr/local/bin/python" \


### PR DESCRIPTION
We made the following changes;

- Locate artifacts under `/tmp` directory to avoid turning off SIP
- Add `packaging` module as a workaround for the missing `packaging` module error

Currently, this PR pass to build

- TensorFlow 2.9.0 with Python 3.8
- TFX 1.9.0 with Python 3.8

In my local environment, this PR failed to build TFX 1.10.0 with Python 3.8. But I think that is another issue.